### PR TITLE
refactor(validator): simplify check_expectations

### DIFF
--- a/src/yatl/exceptions.py
+++ b/src/yatl/exceptions.py
@@ -1,6 +1,6 @@
 class YATLRequestError(Exception):
     """Raised when an HTTP request fails due to a newtwork-level error.
-    
+
     This is exception wraps lower-level transport errors (such as timeouts
     and connection failures) into a single domain-specific exception, providing
     a clear and user-friendly error message.

--- a/src/yatl/request_builder.py
+++ b/src/yatl/request_builder.py
@@ -1,6 +1,8 @@
-import requests
 from typing import Any
+
+import requests
 from requests import Response, request
+
 from yatl.exceptions import YATLRequestError
 
 
@@ -25,7 +27,7 @@ def send_request(context: dict[str, Any], resolved_step: dict[str, Any]) -> Resp
     except requests.exceptions.Timeout as e:
         timeout_value = request_data.get("timeout")
         if timeout_value is not None:
-           msg = f"Request timed out after {timeout_value}s: {request_data['method']} {request_data['url']}"
+            msg = f"Request timed out after {timeout_value}s: {request_data['method']} {request_data['url']}"
         else:
             msg = f"Request timed out (no explicit timeout set): {request_data['method']} {request_data['url']}"
         raise YATLRequestError(msg) from e
@@ -33,7 +35,6 @@ def send_request(context: dict[str, Any], resolved_step: dict[str, Any]) -> Resp
         raise YATLRequestError(
             f"Connection failed: {request_data['method']} {request_data['url']}"
         ) from e
-
 
 
 def build_request_data(

--- a/src/yatl/validator.py
+++ b/src/yatl/validator.py
@@ -9,6 +9,14 @@ from requests import Response
 from .utils import get_content_type, get_nested_value
 
 
+class ContentType(StrEnum):
+    """Enum for supported content types."""
+
+    JSON = "application/json"
+    XML = "application/xml"
+    TEXT = "text/plain"
+
+
 class BodyFormat(StrEnum):
     """Enum for supported body formats."""
 
@@ -31,9 +39,9 @@ class BodyFormat(StrEnum):
         """
 
         mapping = {
-            "application/json": cls.JSON,
-            "application/xml": cls.XML,
-            "text/plain": cls.TEXT,
+            ContentType.JSON: cls.JSON,
+            ContentType.XML: cls.XML,
+            ContentType.TEXT: cls.TEXT,
         }
 
         if content_type in mapping:
@@ -216,6 +224,45 @@ class ResponseValidator:
         except ValueError:
             return None
 
+    def _extract_format_and_spec(
+        self, body_spec: Any, content_type: str
+    ) -> tuple[BodyFormat, Any]:
+        """
+        Extracts the format and spec from the body spec.
+
+        Args:
+            body_spec: The body spec to extract from.
+            content_type: The content-type string.
+
+        Returns:
+            A tuple containing the format and the spec.
+
+        Raises:
+            AssertionError: If the content-type is not supported.
+        """
+        if isinstance(body_spec, dict):
+            for fmt in BodyFormat:
+                if fmt in body_spec:
+                    return fmt, body_spec[fmt]
+
+        try:
+            fmt = BodyFormat.from_content_type(content_type)
+            return fmt, body_spec
+        except ValueError:
+            raise AssertionError(f"Unsupported content-type: {content_type}")
+
+    def _validate_body(self, body_format, body_spec: Any) -> None:
+        """
+        Validates the response body based on format.
+
+        Raises:
+            AssertionError: If the body validation fails.
+        """
+        validator = self._body_validators.get(body_format)
+        if validator is None:
+            raise AssertionError(f"No validator for format: {body_format}")
+        validator(self.response, body_spec)
+
     def check_expectations(self) -> None:
         """Runs all validations defined in the expectation spec.
 
@@ -233,32 +280,5 @@ class ResponseValidator:
             return
 
         content_type = get_content_type(self.response.headers.get("Content-Type", ""))
-        validator = self._get_body_validator(content_type)
-
-        if validator is not None:
-            if isinstance(body_spec, dict) and BodyFormat.JSON in body_spec:
-                validator(self.response, body_spec[BodyFormat.JSON])
-            elif isinstance(body_spec, dict) and BodyFormat.XML in body_spec:
-                validator(self.response, body_spec[BodyFormat.XML])
-            elif isinstance(body_spec, dict) and BodyFormat.TEXT in body_spec:
-                validator(self.response, body_spec[BodyFormat.TEXT])
-            else:
-                if content_type == "application/json":
-                    validate_json_body(self.response, body_spec)
-                elif content_type == "application/xml":
-                    validate_xml_body(self.response, body_spec)
-                elif content_type == "text/plain":
-                    validate_text_body(self.response, body_spec)
-                else:
-                    raise AssertionError(
-                        f"Unsupported body validation for content-type: {content_type}"
-                    )
-        else:
-            if isinstance(body_spec, dict) and BodyFormat.JSON in body_spec:
-                validate_json_body(self.response, body_spec[BodyFormat.JSON])
-            elif isinstance(body_spec, dict) and BodyFormat.TEXT in body_spec:
-                validate_text_body(self.response, body_spec[BodyFormat.TEXT])
-            else:
-                raise AssertionError(
-                    f"Unsupported body validation for content-type: {content_type}"
-                )
+        body_format, body_spec = self._extract_format_and_spec(body_spec, content_type)
+        self._validate_body(body_format, body_spec)

--- a/tests/test_request_builder.py
+++ b/tests/test_request_builder.py
@@ -1,12 +1,16 @@
-from src.yatl.request_builder import build_url, extract_request_params, process_body
-
 from unittest.mock import patch
 
 import pytest
 import requests
 
+from src.yatl.request_builder import (
+    build_url,
+    extract_request_params,
+    process_body,
+    send_request,
+)
 from yatl.exceptions import YATLRequestError
-from src.yatl.request_builder import send_request
+
 
 def test_build_url():
     assert build_url("google.com", "") == "https://google.com/"
@@ -59,7 +63,6 @@ def test_process_body_xml():
     assert headers == {"Content-Type": "application/xml"}
 
 
-
 CONTEXT = {"base_url": "https://api.example.com"}
 
 RESOLVED_STEP = {
@@ -69,12 +72,16 @@ RESOLVED_STEP = {
     }
 }
 
+
 def test_send_request_raises_yatl_request_error_on_timeout_without_value():
     "Test that send_request raises YATLRequestError on timeout with no timeout set."
     with patch("src.yatl.request_builder.request") as mock_request:
         mock_request.side_effect = requests.exceptions.Timeout()
 
-        with pytest.raises(YATLRequestError, match="Request timed out \\(no explicit timeout set\\): GET"):
+        with pytest.raises(
+            YATLRequestError,
+            match="Request timed out \\(no explicit timeout set\\): GET",
+        ):
             send_request(CONTEXT, RESOLVED_STEP)
 
 


### PR DESCRIPTION
Extract format detection and validation logic into separate methods:
`_extract_format_and_spec` and `_validate_body`. 
Reduces complexity from multiple nested conditionals to clear step-by-step process.
