### PR TITLE
bug(validator): str to int fmt (status_code)

### DIFF
--- a/integration_tests/codeforces.yatl.yaml
+++ b/integration_tests/codeforces.yatl.yaml
@@ -1,6 +1,7 @@
 name: codeforces API
 base_url: codeforces.com
 user_name: MikeMirzayanov
+expected_status: 200
 
 steps:
   - name: simple_test
@@ -15,4 +16,4 @@ steps:
           "result.0.firstName": Mike
           "result.0.lastName": Mirzayanov
           "result.0.organization": Codeforces
-      status: 200
+      status: "{{expected_status}}"

--- a/src/yatl/validator.py
+++ b/src/yatl/validator.py
@@ -179,6 +179,8 @@ class ResponseValidator:
             AssertionError: If the status code does not match.
         """
         expected_status = self.expect_spec.get("status")
+        if isinstance(expected_status, str) and expected_status.isdigit():
+            expected_status = int(expected_status)
         if expected_status is not None and self.response.status_code != expected_status:
             raise AssertionError(
                 f"Expected status {expected_status}, got {self.response.status_code}"


### PR DESCRIPTION
Before that change, if you used templates to check status_code, you would get an error. 
> status code 200, expected 200

Bebause status code uses int type, but jinja uses str, this commit checks type and can't raise an exception, for example, before this time, this test got exception:
```yaml
name: codeforces API
base_url: codeforces.com
user_name: MikeMirzayanov
expected_status: 200

steps:
  - name: simple_test
    description: Get information about the user MikeMirzayanov
    request:
      method: GET
      url: /api/user.info?handles={{user_name}}
    expect:
      body:
        json:
          "result.0.handle": MikeMirzayanov
          "result.0.firstName": Mike
          "result.0.lastName": Mirzayanov
          "result.0.organization": Codeforces
      status: "{{expected_status}}"
```