### PR TITLE
fix: report missing test directory

### DIFF
--- a/src/yatl/__main__.py
+++ b/src/yatl/__main__.py
@@ -1,10 +1,12 @@
 """CLI entry point for YATL."""
 
 import argparse
+import sys
 
 from .extractor import DataExtractor
 from .render import TemplateRenderer
 from .run import Runner, run_tests_concurrently
+from .utils import DirectoryNotFoundError
 from .validator import ResponseValidator
 
 
@@ -28,7 +30,11 @@ def main():
 
     runner = Runner(DataExtractor(), TemplateRenderer(), ResponseValidator)
 
-    run_tests_concurrently(runner, test_path=args.path, max_workers=args.workers)
+    try:
+        run_tests_concurrently(runner, test_path=args.path, max_workers=args.workers)
+    except DirectoryNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/src/yatl/utils/__init__.py
+++ b/src/yatl/utils/__init__.py
@@ -2,6 +2,7 @@
 from .base_utils import get_content_type, get_nested_value, is_skipped
 from .context_utils import create_context
 from .file_utils import (
+    DirectoryNotFoundError,
     InvalidYamlError,
     LoadError,
     TestStructureError,
@@ -16,6 +17,7 @@ __all__ = [
     "create_context",
     "search_files",
     "load_test_yaml",
+    "DirectoryNotFoundError",
     "LoadError",
     "InvalidYamlError",
     "TestStructureError",

--- a/src/yatl/utils/file_utils.py
+++ b/src/yatl/utils/file_utils.py
@@ -22,6 +22,12 @@ class TestStructureError(LoadError):
     pass
 
 
+class DirectoryNotFoundError(LoadError):
+    "Directory not found error."
+
+    pass
+
+
 def load_test_yaml(file_path: str) -> dict[str, str | int | list[Any]] | bool:
     """Loads and parses a YAML test file.
 
@@ -54,13 +60,12 @@ def search_files(base_path: str) -> list[str]:
     Returns:
         List of found file paths.
     """
+    if not os.path.isdir(base_path):
+        raise DirectoryNotFoundError(f"Directory does not exist: {base_path}")
+
     files = []
 
     def _search(current_path: str):
-        try:
-            os.listdir(current_path)
-        except FileNotFoundError:
-            return
         for item in os.listdir(current_path):
             full_path = os.path.join(current_path, item)
             if os.path.isfile(full_path) and (

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,6 +1,12 @@
 import pytest
 
-from src.yatl.utils import create_context, is_skipped, load_test_yaml, search_files
+from src.yatl.utils import (
+    DirectoryNotFoundError,
+    create_context,
+    is_skipped,
+    load_test_yaml,
+    search_files,
+)
 
 
 def test_create_context_with_valid_data_returns_context(data):
@@ -44,6 +50,8 @@ def test_search_files():
 
 
 def test_search_files_with_invalid_path():
-    "Test that search_files returns an empty list with invalid path."
-    files = search_files("tests/data/not_found")
-    assert len(files) == 0
+    "Test that search_files raises a clear error with invalid path."
+    with pytest.raises(
+        DirectoryNotFoundError, match="Directory does not exist: tests/data/not_found"
+    ):
+        search_files("tests/data/not_found")


### PR DESCRIPTION
## Summary
- add a DirectoryNotFoundError for missing test directories
- surface the error through the CLI with a clear non-zero exit instead of reporting no test files
- update the search_files invalid-path test

## Validation
- PYTHONPATH=src:. /tmp/codex-yatl-venv/bin/python -m pytest
- PYTHONPATH=src /tmp/codex-yatl-venv/bin/python -m yatl /tmp/definitely-missing-yatl-dir
- /tmp/codex-yatl-venv/bin/ruff check .
- git diff --check

Closes #96.